### PR TITLE
Generate token after 15 minutes

### DIFF
--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -150,7 +150,7 @@ class Api:
 	@property
 	def token(self):
 		# generate a new token every 15 minutes
-		if not self._token or self.token_gen_date + timedelta(minutes=15) > datetime.now():
+		if (self._token is None) or (self.token_gen_date + timedelta(minutes=15) < datetime.now()):
 			self._token = self._generate_token()
 
 		return self._token


### PR DESCRIPTION
I found that _token property, defined as None as default, is not checked correctly.
Infact in python there is the following behaviour:

`token = None`
`(not token) => False`
But also:
`token = "value_string"`
`(not token) => False`

The correct check is obtained through a compared NoneType value.

I also changed the sign of timestamp check.

**Changes made:**
- check token NoneType to validate parameter

- define right expiration timestamp