### PR TITLE
Add split_response to download_finance_reports()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ git
 
 # Apple AuthKeys
 AuthKey_*
+
+# Files used or generated during dev/tetsing
+*.csv
+*.p8
+test_api_gc.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.8.2
+
+Features:
+ - New `split_response` argument in `download_finance_reports()` function that splits the response into 2 objects. Defualt value is `split_response=False`. This also
+ allows the 2 responses to be saved to separate files using a syntax like `save_to=['test1.csv', 'test2.csv']`.
+
+
 ## 0.8.1
 
 Bugfixes:

--- a/appstoreconnect/__version__.py
+++ b/appstoreconnect/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 8, 1)
+VERSION = (0, 8, 2)
 
 __version__ = '.'.join(map(str, VERSION))

--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -539,7 +539,7 @@ class Api:
 		return self._get_resources(Profile, filters, sort)
 
 	# Reporting
-	def download_finance_reports(self, filters=None, save_to=None):
+	def download_finance_reports(self, filters=None, split_response=False, save_to=None):
 		# setup required filters if not provided
 		for required_key, default_value in (
 				('regionCode', 'ZZ'),
@@ -553,6 +553,18 @@ class Api:
 		url = "%s%s" % (BASE_API, FinanceReport.endpoint)
 		url = self._build_query_parameters(url, filters)
 		response = self._api_call(url)
+
+		if split_response:
+			res1 = response.split('Total_Rows')[0]
+			res2 = '\n'.join(response.split('Total_Rows')[1].split('\n')[1:])
+
+			if save_to:
+				file1 = Path(save_to[0])
+				file1.write_text(res1, 'utf-8')
+				file2 = Path(save_to[1])
+				file2.write_text(res2, 'utf-8')
+
+			return res1, res2
 
 		if save_to:
 			file = Path(save_to)


### PR DESCRIPTION
@ppawlak 

This PR addresses the issues we have discussed in #21. I've bumped the version and updated the CHANGELOG as well so its ready for pypi but I can revert that if you want.

New functionality (you can test locally for your own check):
```python
key_id = 'foo_bar'
path_to_key_file = './foo_bar.p8'
issuer_id = 'foo_bar_foo_bar'

api = Api(
        key_id,
        path_to_key_file,
        issuer_id,
        submit_stats=False
      )

res1, res2 = api.download_finance_reports(
     filters={
         'vendorNumber': 'foo_bar',
         'reportDate': '2020-07',
         'reportType': 'FINANCIAL'
     },
     split_response=True,
     save_to=['test1.csv', 'test2.csv']  # Saves as 2 files 
 )

print(res1)

print('\n')

print(res2)
```
