### PR TITLE
Expose the HTTP status code when App Store Connect API response raises APIError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ git
 # Apple AuthKeys
 AuthKey_*
 
+# VSCode
+.vscode
+
 # Files used or generated during dev/tetsing
 *.csv
 *.p8

--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,5 @@ AuthKey_*
 # Files used or generated during dev/tetsing
 *.csv
 *.p8
-test_api_gc.py
+test_api_sales.py
+test_api_finance.py

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ AuthKey_*
 # VSCode
 .vscode
 
-# Files used or generated during dev/tetsing
+# Files used or generated during dev/testing
 *.csv
 *.p8
 test_api_sales.py

--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -25,7 +25,9 @@ class HttpMethod(Enum):
 
 
 class APIError(Exception):
-	pass
+	def __init__(self, error_string, error_code):
+		self.code = error_code
+		super().__init__(error_string)
 
 
 class Api:
@@ -219,7 +221,10 @@ class Api:
 		if content_type in [ "application/json", "application/vnd.api+json" ]:
 			payload = r.json()
 			if 'errors' in payload:
-				raise APIError(payload.get('errors', [])[0].get('detail', 'Unknown error'))
+				raise APIError(
+					payload.get('errors', [])[0].get('detail', 'Unknown error'),
+				 	payload.get('errors', [])[0].get('status', None)
+				)
 			return payload
 		elif content_type == 'application/a-gzip':
 			# TODO implement stream decompress
@@ -610,4 +615,3 @@ class Api:
 			file.write_text(response, 'utf-8')
 
 		return response
-


### PR DESCRIPTION
This PR addresses #26.

Now, when an `APIError` is [raised](https://github.com/Ponytech/appstoreconnectapi/blob/ddc8f13d1db2c4dea8c87949e749cb2b5e883568/appstoreconnect/api.py#L219-L223), the HTTP status code (see [docs](https://developer.apple.com/documentation/appstoreconnectapi/interpreting_and_handling_errors/about_the_http_status_code)) is accessible using the `.code` attribute of the `APIError` object.

### Example
`test_api_error.py`
```python
from appstoreconnect import Api
from appstoreconnect.api import APIError  # type: ignore

key_id = 'foo_bar'
path_to_key_file = './foo_bar.p8'
issuer_id = 'foo_bar'

api = Api(
    key_id,
    path_to_key_file,
    issuer_id,
    submit_stats=False
)

try:
    res = api.download_sales_and_trends_reports(
        filters={
            'vendorNumber': 'foo_bar',
            'reportDate': '2021-01-01',  # THIS IS NEXT YEAR, THEREFORE  404 "NOT FOUND" ERROR EXPECTED
            'reportType': 'SALES'
        }
    )
except APIError as e:
            # Only except certain errors, full list of possible errors is found here:
            # https://developer.apple.com/documentation/appstoreconnectapi/interpreting_and_handling_errors/about_the_http_status_code
            if int(e.code) == 404:
                print("caught 404 error")
            else:
                raise e
```

Running the above script shows that the 404 error is caught using the `.code` attribute of `APIError`.
```bash
▶ python test_api_error.py
caught 404 error
```