### PR TITLE
Relaxing cryptography dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ VERSION = None
 REQUIRED = [
     'requests>=2.20.1,==2.*',
     'PyJWT>=1.6.4,==1.*',
-    'cryptography>=2.6.1,==2.*',
+    'cryptography>=2.6.1',
 ]
 
 EXTRAS = {


### PR DESCRIPTION
The current restriction is no higher than version 2, although for more than two and a half years the third version.
I am currently using 38.0.4 and everything works without any problems.