### PR TITLE
Fix apple api returning unsorted data

### DIFF
--- a/appstoreconnect/api.py
+++ b/appstoreconnect/api.py
@@ -355,14 +355,14 @@ class Api:
 		"""
 		return self._modify_resource(user, locals())
 
-	def list_users(self, filters=None, sort=None):
+	def list_users(self, filters=None, sort="username"):
 		"""
 		:reference: https://developer.apple.com/documentation/appstoreconnectapi/list_users
 		:return: an iterator over User resources
 		"""
 		return self._get_resources(User, filters, sort)
 
-	def list_invited_users(self, filters=None, sort=None):
+	def list_invited_users(self, filters=None, sort="email"):
 		"""
 		:reference: https://developer.apple.com/documentation/appstoreconnectapi/list_invited_users
 		:return: an iterator over UserInvitation resources


### PR DESCRIPTION
Apple has changed something on their end broke the paging functionality of listing users and invites without a sorting key.

I think it's sensible to default sorting users by "username" and invites by "email" to avoid this problem. (it's beyond me why apple uses "username" for users and "email" for invites)